### PR TITLE
Improve handling of custom domains that are already setup

### DIFF
--- a/.zf/config.ps1
+++ b/.zf/config.ps1
@@ -34,20 +34,7 @@ task . FullBuild
 # task PostInit {}
 # task PreVersion {}
 # task PostVersion {}
-task PreBuild {
-    if (!$IsRunningOnCICDServer) {
-        # Whwn running locally, ensure the lockfile template is up-to-date
-        Set-Location (Join-Path $here 'module' 'templates')
-        try {
-            Copy-Item vite-package.template.json package.json -Force
-            exec { npm install --package-lock-only }
-            Copy-Item package-lock.json vite-package-lock.template.json
-        }
-        finally {
-            Remove-Item package*.json
-        }
-    }
-}
+# task PreBuild {}
 # task PostBuild {}
 # task PreTest {}
 # task PostTest {}

--- a/module/functions/Get-SWACustomDomainValidationToken.Tests.ps1
+++ b/module/functions/Get-SWACustomDomainValidationToken.Tests.ps1
@@ -1,0 +1,261 @@
+# <copyright file="Get-SWACustomDomainValidationToken.Tests.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+BeforeAll {
+    # Import the function under test
+    . $PSScriptRoot\Get-SWACustomDomainValidationToken.ps1
+}
+
+Describe 'Get-SWACustomDomainValidationToken' {
+    
+    Context 'When custom domain exists with validation token' {
+
+        It 'Should return the validation token immediately' {
+            Mock Get-AzStaticWebAppCustomDomain {
+                return [PSCustomObject]@{
+                    Domain = 'test.com'
+                    ValidationToken = 'abc123token'
+                }
+            }
+
+            $result = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com'
+            
+            $result | Should -Be 'abc123token'
+            Should -Invoke Get-AzStaticWebAppCustomDomain -Times 1 -ParameterFilter {
+                                                                        $ResourceGroupName -eq 'test-rg' -and
+                                                                        $Name -eq 'test-swa' -and
+                                                                        $DomainName -eq 'test.com' }
+        }
+    }
+
+    Context 'When custom domain does not exist' {
+        
+        BeforeEach {
+            Mock Get-AzStaticWebAppCustomDomain { return $null }
+            Mock Write-Information {}
+        }
+
+        It 'Should return null when custom domain is not configured' {
+            $result = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com'
+            
+            $result | Should -BeNullOrEmpty
+            Should -Invoke Get-AzStaticWebAppCustomDomain -Times 1
+        }
+
+        It 'Should write information message when domain not found' {
+            $informationMessages = @()
+            Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com'
+            
+            Should -Invoke Write-Information -ParameterFilter { $MessageData -eq "The site 'test-swa' is not configured with the custom domain 'test.com'" }
+        }
+    }
+
+    Context 'When custom domain exists but validation token is initially empty' {
+        
+        It 'Should poll until token becomes available' {
+            # First call returns empty token, second call returns token
+            Mock Get-AzStaticWebAppCustomDomain {
+                if ($script:CallCount -eq $null) { $script:CallCount = 0 }
+                $script:CallCount++
+                
+                if ($script:CallCount -eq 1) {
+                    return [PSCustomObject]@{
+                        Domain = 'test.com'
+                        ValidationToken = ''
+                    }
+                } else {
+                    return [PSCustomObject]@{
+                        Domain = 'test.com'
+                        ValidationToken = 'delayed-token-123'
+                    }
+                }
+            }
+            
+            Mock Start-Sleep { }  # Speed up the test
+            
+            $result = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -PollingIntervalSeconds 1
+            
+            $result | Should -Be 'delayed-token-123'
+            Should -Invoke Get-AzStaticWebAppCustomDomain -Times 2
+            Should -Invoke Start-Sleep -Times 1 -ParameterFilter { $Seconds -eq 1 }
+            
+            # Clean up script variable
+            Remove-Variable -Name CallCount -Scope Script -ErrorAction SilentlyContinue
+        }
+
+        It 'Should respect custom polling interval' {
+            Mock Get-AzStaticWebAppCustomDomain {
+                return [PSCustomObject]@{
+                    Domain = 'test.com'
+                    ValidationToken = ''
+                }
+            }
+            
+            Mock Start-Sleep { }
+            
+            { Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -PollingIntervalSeconds 30 -MaxPollingAttempts 2 } | 
+                Should -Throw
+            
+            Should -Invoke Start-Sleep -Times 1 -ParameterFilter { $Seconds -eq 30 }
+        }
+    }
+
+    Context 'When maximum polling attempts are exceeded' {
+        
+        BeforeEach {
+            Mock Get-AzStaticWebAppCustomDomain {
+                return [PSCustomObject]@{
+                    Domain = 'test.com'
+                    ValidationToken = $null  # Always null/empty
+                }
+            }
+            Mock Start-Sleep { }  # Speed up the test
+        }
+
+        It 'Should throw exception when max attempts exceeded' {
+            { Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -MaxPollingAttempts 3 } | 
+                Should -Throw -ExpectedMessage "*validation token could not be retrieved after 3 attempts*"
+        }
+
+        It 'Should call Azure API the correct number of times' {
+            { Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -MaxPollingAttempts 2 } | 
+                Should -Throw
+            
+            Should -Invoke Get-AzStaticWebAppCustomDomain -Times 2
+        }
+
+        It 'Should sleep between attempts but not after the last attempt' {
+            { Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -MaxPollingAttempts 3 -PollingIntervalSeconds 1 } | 
+                Should -Throw
+            
+            # Should sleep 2 times (between attempts 1-2 and 2-3, but not after attempt 3)
+            Should -Invoke Start-Sleep -Times 2 -ParameterFilter { $Seconds -eq 1 }
+        }
+    }
+
+    Context 'When Azure API throws exceptions' {
+        
+        It 'Should handle and retry on API exceptions' {
+            Mock Get-AzStaticWebAppCustomDomain {
+                if ($script:ApiCallCount -eq $null) { $script:ApiCallCount = 0 }
+                $script:ApiCallCount++
+                
+                if ($script:ApiCallCount -eq 1) {
+                    throw "Azure API Error"
+                } else {
+                    return [PSCustomObject]@{
+                        Domain = 'test.com'
+                        ValidationToken = 'recovered-token'
+                    }
+                }
+            }
+            
+            Mock Start-Sleep { }
+            Mock Write-Warning {}
+            
+            $result = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com'
+            
+            $result | Should -Be 'recovered-token'
+            Should -Invoke Get-AzStaticWebAppCustomDomain -Times 2
+            
+            # Clean up script variable
+            Remove-Variable -Name ApiCallCount -Scope Script -ErrorAction SilentlyContinue
+        }
+
+        It 'Should throw exception when all retry attempts fail' {
+            Mock Get-AzStaticWebAppCustomDomain { throw "Persistent Azure API Error" }
+            Mock Start-Sleep { }
+            Mock Write-Warning {}
+            
+            { Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -MaxPollingAttempts 2 } | 
+                Should -Throw -ExpectedMessage "*validation token could not be retrieved after 2 attempts*"
+        }
+
+        It 'Should write warning messages for caught exceptions' {
+            Mock Get-AzStaticWebAppCustomDomain { throw "Test Exception" }
+            Mock Start-Sleep { }
+            Mock Write-Warning {}
+            
+            $warningMessages = @()
+            {
+                Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -MaxPollingAttempts 1
+            } | Should -Throw
+            
+            Should -Invoke Write-Warning -ParameterFilter { $Message -like "*Error occurred while retrieving custom domain information on attempt 1*Test Exception*" }
+        }
+    }
+
+    Context 'Integration scenarios' {
+
+        BeforeEach {
+            Mock Write-Warning {}
+        }
+        
+        It 'Should handle mixed scenarios: exception then empty token then success' {
+            Mock Get-AzStaticWebAppCustomDomain {
+                if ($script:MixedCallCount -eq $null) { $script:MixedCallCount = 0 }
+                $script:MixedCallCount++
+                
+                switch ($script:MixedCallCount) {
+                    1 { throw "Temporary API Error" }
+                    2 { 
+                        return [PSCustomObject]@{
+                            Domain = 'test.com'
+                            ValidationToken = ''
+                        }
+                    }
+                    default { 
+                        return [PSCustomObject]@{
+                            Domain = 'test.com'
+                            ValidationToken = 'final-success-token'
+                        }
+                    }
+                }
+            }
+            
+            Mock Start-Sleep { }
+            
+            $result = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com'
+            
+            $result | Should -Be 'final-success-token'
+            Should -Invoke Get-AzStaticWebAppCustomDomain -Times 3
+            Should -Invoke Start-Sleep -Times 2  # Once after exception, once after empty token
+            
+            # Clean up script variable
+            Remove-Variable -Name MixedCallCount -Scope Script -ErrorAction SilentlyContinue
+        }
+
+        It 'Should work with default parameter values' {
+            Mock Get-AzStaticWebAppCustomDomain {
+                return [PSCustomObject]@{
+                    Domain = 'test.com'
+                    ValidationToken = 'default-params-token'
+                }
+            }
+            
+            $result = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com'
+            
+            $result | Should -Be 'default-params-token'
+        }
+    }
+
+    Context 'Verbose output validation' {
+        
+        It 'Should write appropriate verbose messages during polling' {
+            Mock Get-AzStaticWebAppCustomDomain {
+                return [PSCustomObject]@{
+                    Domain = 'test.com'
+                    ValidationToken = 'immediate-token'
+                }
+            }
+            
+            $res = Get-SWACustomDomainValidationToken -ResourceGroupName 'test-rg' -Name 'test-swa' -Domain 'test.com' -Verbose 4>&1
+            
+            $res[0] | Should -Be "Starting to poll for custom domain validation token for domain 'test.com' on Static Web App 'test-swa'"
+            $res[1] | Should -Be "Polling attempt 1 of 8"
+            $res[2] | Should -Be "Custom domain validation token for site 'test-swa' and domain 'test.com' found on attempt 1"
+            $res[3] | Should -Be "immediate-token"
+        }
+    }
+}

--- a/module/functions/Get-SWACustomDomainValidationToken.Tests.ps1
+++ b/module/functions/Get-SWACustomDomainValidationToken.Tests.ps1
@@ -5,6 +5,13 @@
 BeforeAll {
     # Import the function under test
     . $PSScriptRoot\Get-SWACustomDomainValidationToken.ps1
+
+    # Make a stub of the cmdlet from the Az.Websites module available for mocking,
+    # to avoid actually needing the module installed so Pester can auto-mock it.
+    function Get-AzStaticWebAppCustomDomain {
+        [CmdletBinding()]
+        param ($ResourceGroupName, $Name, $DomainName)
+    }
 }
 
 Describe 'Get-SWACustomDomainValidationToken' {

--- a/module/functions/Get-SWACustomDomainValidationToken.ps1
+++ b/module/functions/Get-SWACustomDomainValidationToken.ps1
@@ -1,0 +1,137 @@
+# <copyright file="Get-SWACustomDomainValidationToken.ps1" company="Endjin Limited">
+# Copyright (c) Endjin Limited. All rights reserved.
+# </copyright>
+
+<#
+.SYNOPSIS
+    Retrieves the validation token for a custom domain configured on an Azure Static Web App.
+
+.DESCRIPTION
+    This function polls an Azure Static Web App to retrieve the validation token for a specified custom domain.
+    The validation token is required to prove domain ownership when setting up custom domains.
+    
+    The function implements a retry mechanism with configurable polling intervals and maximum attempts,
+    as the validation token may not be immediately available after domain configuration.
+
+.PARAMETER ResourceGroupName
+    The name of the Azure resource group containing the Static Web App.
+
+.PARAMETER Name
+    The name of the Azure Static Web App.
+
+.PARAMETER Domain
+    The custom domain name for which to retrieve the validation token (e.g., "www.example.com").
+
+.PARAMETER PollingIntervalSeconds
+    The number of seconds to wait between polling attempts when the validation token is not yet available.
+    Default value is 15 seconds.
+
+.PARAMETER MaxPollingAttempts
+    The maximum number of polling attempts before giving up and throwing an error.
+    Default value is 8 attempts.
+
+.OUTPUTS
+    System.String
+    Returns the validation token as a string if found, or $null if no custom domain is configured.
+
+.EXAMPLE
+    Get-SWACustomDomainValidationToken -ResourceGroupName "rg-myapp" -Name "myapp-swa" -Domain "www.myapp.com"
+    
+    Retrieves the validation token for the domain "www.myapp.com" configured on the Static Web App "myapp-swa"
+    in resource group "rg-myapp" using default polling settings.
+
+.EXAMPLE
+    Get-SWACustomDomainValidationToken -ResourceGroupName "rg-myapp" -Name "myapp-swa" -Domain "api.myapp.com" -PollingIntervalSeconds 30 -MaxPollingAttempts 5
+    
+    Retrieves the validation token with custom polling settings: 30-second intervals and maximum 5 attempts.
+
+.NOTES
+    - Requires the Az.Websites PowerShell module to be installed and imported
+    - The user must be authenticated to Azure with appropriate permissions to read Static Web App configurations
+    - If the custom domain is not configured on the Static Web App, the function returns $null
+    - If the validation token cannot be retrieved within the specified attempts, an exception is thrown
+
+.LINK
+    https://docs.microsoft.com/en-us/azure/static-web-apps/custom-domain
+
+.LINK
+    Get-AzStaticWebAppCustomDomain
+#>
+function Get-SWACustomDomainValidationToken {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $ResourceGroupName,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Domain,
+
+        [Parameter()]
+        [ValidateRange(1, 300)]
+        [int] $PollingIntervalSeconds = 15,
+
+        [Parameter()]
+        [ValidateRange(1, 50)]
+        [int] $MaxPollingAttempts = 8
+    )
+
+    # Initialize attempt counter
+    $currentAttempt = 0
+    
+    Write-Verbose "Starting to poll for custom domain validation token for domain '$Domain' on Static Web App '$Name'"
+    
+    while ($currentAttempt -lt $MaxPollingAttempts) {
+        $currentAttempt++
+        Write-Verbose "Polling attempt $currentAttempt of $MaxPollingAttempts"
+        
+        try {
+            # Retrieve the custom domain configuration from Azure
+            $customDomain = Get-AzStaticWebAppCustomDomain `
+                                        -ResourceGroupName $ResourceGroupName `
+                                        -Name $Name `
+                                        -Domain $Domain `
+                                        -ErrorAction SilentlyContinue
+
+            if ($customDomain) {
+                # Custom domain exists, check if validation token is available
+                if ([string]::IsNullOrEmpty($customDomain.ValidationToken)) {
+                    Write-Verbose "Custom domain validation token for site '$Name' and domain '$Domain' is not yet available"
+                    
+                    if ($currentAttempt -lt $MaxPollingAttempts) {
+                        Write-Verbose "Will re-check in $PollingIntervalSeconds seconds (attempt $currentAttempt of $MaxPollingAttempts)"
+                        Start-Sleep -Seconds $PollingIntervalSeconds
+                    }
+                }
+                else {
+                    Write-Verbose "Custom domain validation token for site '$Name' and domain '$Domain' found on attempt $currentAttempt"
+                    return $customDomain.ValidationToken
+                }
+            }
+            else {
+                # Custom domain not found - this means it's not configured
+                Write-Information "The site '$Name' is not configured with the custom domain '$Domain'" -InformationAction Continue
+                return $null
+            }
+        }
+        catch {
+            Write-Warning "Error occurred while retrieving custom domain information on attempt $currentAttempt`: $($_.Exception.Message)"
+            
+            if ($currentAttempt -lt $MaxPollingAttempts) {
+                Write-Verbose "Will retry in $PollingIntervalSeconds seconds"
+                Start-Sleep -Seconds $PollingIntervalSeconds
+            }
+        }
+    }
+
+    # If we reach here, all attempts have been exhausted
+    $errorMessage = "The site '$Name' is configured with the custom domain '$Domain', but the validation token could not be retrieved after $currentAttempt attempts"
+    throw $errorMessage
+}
+        

--- a/module/tasks/deploy.tasks.ps1
+++ b/module/tasks/deploy.tasks.ps1
@@ -35,12 +35,12 @@ task ConfigureCustomDomainWithAzureDns -After ProvisionCore -If { $deploymentCon
     # so it can be validated.
     #
     # NOTE: This script assumes that the domain name registration is already delegated to Azure DNS for resolution.
-    $site = Get-AzStaticWebApp -ResourceGroupName $ResourceGroupName `
-                                       -Name $Name `
-                                       -ErrorAction Ignore
+    $site = Get-AzStaticWebApp -ResourceGroupName $deploymentConfig.resourceGroupName `
+                               -Name $deploymentConfig.siteName `
+                               -ErrorAction Ignore
 
     if (!$site) {
-        throw "The Azure Static Web App not found: [ResourceGroup=$ResourceGroupName] [Name=$Name]"
+        throw "The Azure Static Web App not found: [ResourceGroup=$($deploymentConfig.resourceGroupName)] [Name=$($deploymentConfig.siteName)]"
     }
 
     # Call SWA REST API directly since the 'Get-AzStaticWebAppCustomDomain' cmdlet does not surface the custom domain's status details

--- a/module/tasks/deploy.tasks.ps1
+++ b/module/tasks/deploy.tasks.ps1
@@ -69,8 +69,7 @@ task ConfigureCustomDomainWithAzureDns -After ProvisionCore -If { $deploymentCon
         $customDomain = $customDomainResp |
                             Select-Object -ExpandProperty Content |
                             ConvertFrom-Json -Depth 100 |
-                            Select-Object -ExpandProperty properties |
-                            ConvertFrom-Json -Depth 100
+                            Select-Object -ExpandProperty properties
 
         # If the domain is already fully-configured then there is nothing further to do
         if ($customDomain.status -eq 'Ready') {


### PR DESCRIPTION
Now uses the SWA ARM REST API rather than the Az cmdlet to query the custom domain status, so we don't needlessly check the DNS configuration if everything is already reported as being setup correctly.

New behaviour validated here:
https://github.com/endjin/fabric-weekly-info/actions/runs/16746331270/job/47405645734#step:4:186