### PR TITLE
Add optional apiLocation input for SWA managed functions

### DIFF
--- a/actions/vellum-site-deploy/action.yml
+++ b/actions/vellum-site-deploy/action.yml
@@ -22,6 +22,10 @@ inputs:
   swaSiteName:
     description: 'The name of the Azure Static Web App'
     required: true
+  apiLocation:
+    description: 'Relative path to the Azure Functions API source code for SWA managed functions. Leave empty for sites without an API.'
+    required: false
+    default: ''
 
 
 runs:
@@ -122,4 +126,5 @@ runs:
       repo_token: ${{ inputs.githubToken }} # Used for Github integrations (i.e. PR comments)
       action: upload
       app_location: website
+      api_location: ${{ inputs.apiLocation }}
       skip_app_build: true

--- a/actions/vellum-site-deploy/action.yml
+++ b/actions/vellum-site-deploy/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'The name of the Azure Static Web App'
     required: true
   apiLocation:
-    description: 'Relative path to the Azure Functions API source code for SWA managed functions. Leave empty for sites without an API.'
+    description: 'Relative path to the Azure Functions API source code for SWA managed functions. The directory must exist in the workspace at deploy time (typically via actions/checkout in a prior step). Leave empty for sites without an API.'
     required: false
     default: ''
 
@@ -116,6 +116,16 @@ runs:
       }
       Add-Content -Path $env:GITHUB_OUTPUT -Value "SWA_API_TOKEN=$apiToken"
       Write-Host "::add-mask::$apiToken"
+
+  - name: Validate API location
+    if: ${{ inputs.apiLocation != '' }}
+    shell: bash
+    run: |
+      if [ ! -d "${{ inputs.apiLocation }}" ]; then
+        echo "::error::apiLocation '${{ inputs.apiLocation }}' does not exist in the workspace. Ensure the repository is checked out (actions/checkout) or the API source is included in the build artefact."
+        exit 1
+      fi
+      echo "API location validated: ${{ inputs.apiLocation }}"
 
   - name: Deploy
     id: deploy


### PR DESCRIPTION
## Summary
- Adds an optional `apiLocation` input to the vellum-site-deploy action
- Passes it through to `azure/static-web-apps-deploy` as `api_location`
- Default is empty string, so existing sites without an API are unaffected

This enables Azure Static Web Apps deployments to include an Azure Functions API backend (e.g., for dynamic URL redirects).

## Usage
```yaml
- uses: endjin/Endjin.ZeroFailed.Deploy.Vellum/actions/vellum-site-deploy@main
  with:
    apiLocation: api    # path to Azure Functions source
    # ... existing params
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)